### PR TITLE
[feat] before-exception hook for improved exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.5.6-beta - 2025-10-16
+
+### What's Changed
+
+* composer.json updated for beta environment by [@techmahedy](https://github.com/techmahedy) in https://github.com/doppar/doppar/pull/8
+
+**Full Changelog**: https://github.com/doppar/doppar/compare/2.5.5...2.5.6-beta
+
 ## 2.5.5 - 2025-10-15
 
 ### What's Changed

--- a/app/Http/Exceptions/BeforeExceptionHandler.php
+++ b/app/Http/Exceptions/BeforeExceptionHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Exceptions;
+
+use Throwable;
+use Phaseolies\Error\Contracts\ErrorHandlerInterface;
+
+class BeforeExceptionHandler implements ErrorHandlerInterface
+{
+    /**
+     * Handle logic to be executed before the application processes an exception
+     *
+     * @param Throwable $throwable
+     * @return void
+     */
+    public function handle(Throwable $throwable): void
+    {
+        //
+    }
+
+    /**
+     * Determine if this handler should run for the current context
+     *
+     * @return bool
+     */
+    public function supports(): bool
+    {
+        return true;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -67,6 +67,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sensitive Input Exclusions
+    |--------------------------------------------------------------------------
+    |
+    | Define the list of sensitive input fields that should never be stored
+    | in the session. This helps protect sensitive data such as passwords
+    | from being exposed or persisted.
+    |
+    */
+    "exclude_sensitive_input" => [
+        'password',
+        '_insight_redirect_chain'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Locale Configuration
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This update introduces a before-exception hook that enables logging of exceptions before they are thrown in the Doppar application.

It enhances observability and debugging by capturing exception context at the earliest possible stage.

With this change, developers can now easily handle exceptions at the application level, allowing for more flexible and consistent error management.

This update enhances session input handling by preventing sensitive user data, such as passwords and other important fields, from being stored in the session

The list of excluded fields is now configurable via config/app.php, allowing developers to easily customize it based on their application’s security requirements.

Benefits

Enhanced Security: Prevents exposure of confidential data in session storage.
Better Maintainability: Centralized exclusion list for sensitive fields.
Tested with custom exclusion lists defined in config/app.php.

```
"exclude_sensitive_input" => [
        'password',
        '_insight_redirect_chain'
],
```