### PR TITLE
exists_in new input validation key

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -6,7 +6,7 @@
 |--------------------------------------------------------------------------
 |
 | This configuration file defines the database connection settings for the
-| application. It supports database connections MySQL, SQLite and PostgreSQL.  Database credentials and settings are primarily
+| application. It supports database connections MySQL, SQLite and PostgreSQL. Database credentials and settings are primarily
 | loaded from the ".env" file to maintain security and flexibility.
 |
 | Supported Drivers: mysql, sqlite, pgsql
@@ -45,7 +45,6 @@ return [
 
         'pgsql' => [
             'driver' => 'pgsql',
-            'url' => env('DB_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'doppar'),

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -3,6 +3,7 @@
 return [
     'default' => 'The given data was invalid.',
     'required' => 'The :attribute field is required',
+    'exists_in' => 'The selected :attribute is invalid.',
     'email' => 'The :attribute must be a valid email address.',
     'min' => [
         'string' => 'The :attribute must be at least :min characters.',


### PR DESCRIPTION
Summary
- Introduced a new validation key: `exists_in`.
- This rule checks whether a given input value exists in a specified database table and column.

Usage example:
```php
$request->sanitize([
    'category_id' => 'required|exists_in:category,id'
]);
```

Details
- `exists_in:<table>,<column> `ensures referential integrity at the validation layer.
- Prevents invalid foreign key values before database operations.

Here, passing the column name after the table is optional; by default, it uses the id
```php
'category_id' => 'exists_in:category' // defaults to column 'id'
```

Improves referential data validation at the request level.
