### PR TITLE
Introducing [odo] template engine for doppar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto eol=lf
 
-*.blade.php diff=html
+*.odo.php diff=html
 *.css diff=css
 *.html diff=html
 *.md diff=markdown

--- a/config/odo.php
+++ b/config/odo.php
@@ -1,0 +1,78 @@
+
+<?php
+
+/**
+ * =========================================
+ * ODO TEMPLATE ENGINE CONFIGURATION
+ * =========================================
+ *
+ * This configuration file allows you to customize the syntax
+ * of odo template engine beyond standard syntax.
+ */
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Directive Prefix
+    |--------------------------------------------------------------------------
+    |
+    | The character used to prefix directives. Default to '#'.
+    | You can change this to any single character like '#', '$', '%', '~', etc.
+    |
+    | Example: '#if', '$foreach', '%include'
+    |
+    */
+    'directive_prefix' => '#',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Echo Tags
+    |--------------------------------------------------------------------------
+    |
+    | Configure the opening and closing tags for outputting variables.
+    |
+    | Example: [[ $variable ]]
+    |
+    */
+    'open_echo' => '[[',
+    'close_echo' => ']]',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Raw Echo Tags
+    |--------------------------------------------------------------------------
+    |
+    | Configure tags for unescaped output (raw HTML).
+    |
+    | Example: [[! $html !]]
+    |
+    */
+    'open_raw_echo' => '[[!',
+    'close_raw_echo' => '!]]',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Escaped Echo Tags
+    |--------------------------------------------------------------------------
+    |
+    | Configure tags for explicitly escaped output.
+    |
+    | Example: [[[ $variable ]]]
+    |
+    */
+    'open_escaped_echo' => '[[[',
+    'close_escaped_echo' => ']]]',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Comment Tags
+    |--------------------------------------------------------------------------
+    |
+    | Configure tags for template comments.
+    |
+    | Example: [[-- This is a comment --]]
+    |
+    */
+    'open_comment' => '[[--',
+    'close_comment' => '--]]',
+];

--- a/resources/views/welcome.odo.php
+++ b/resources/views/welcome.odo.php
@@ -11,11 +11,11 @@
     </head>
     <body>
         <header>
-            <img src="{{ enqueue('logo.png') }}" alt="Logo" />
+            <img src="[[ enqueue('logo.png') ]]" alt="Logo" />
             <h2>Welcome to Doppar</h2>
         </header>
         <section class="cta-box">
-            <h3>{{ trans('messages.welcome', ['version' => 'v' . Application::VERSION]) }}</h3>
+            <h3>[[ trans('messages.welcome', ['version' => 'v' . Application::VERSION]) ]]</h3>
             <p>Craft Fast-Loading PHP Application</p>
         </section>
         <section class="grid">
@@ -42,7 +42,7 @@
             <a href="https://doppar.com" class="btn">Website</a>
         </div>
         <div class="footer">
-            PHP {{ phpversion() }}
+            PHP [[ phpversion() ]]
         </div>
     </body>
 </html>


### PR DESCRIPTION
This pull request removes the default Blade template engine integration and introduces our own custom template engine: ODO. Since we have built and maintained our own templating system internally, continuing to rely on Blade is unnecessary and inconsistent with our framework’s branding and architecture.

This PR ensures that our templates strictly follow ODO syntax, making our Doppar Framework cleaner, unified, and fully independent.

## Added ODO Template Engine Configuration
Created `config/odo.php`, which defines all syntax controls for the ODO engine:

1. Directive prefix
2. Echo tags
3. Raw echo tags
4. Escaped echo tags
5. Comment tags

This allows full customization and ensures consistency across our view layer.

All future views will use ODO syntax exclusively. Blade is no longer part of our rendering pipeline. Framework becomes lighter, more flexible, and branded.

## Final Notes

This PR represents a key step toward making the Doppar Framework truly framework-independent, cohesive, and self-branded. ODO is our engine — so our templates should reflect that consistently.