### PR TITLE
Fix: PHP 8.5 PDO MySQL Constant Deprecations (Backward Compatible)

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -38,9 +38,23 @@ return [
             'prefix' => env('DB_PREFIX', ''),
             'strict' => env('DB_STRICT_MODE', true),
             'engine' => env('DB_ENGINE', null),
-            'options' => extension_loaded('pdo_mysql') ? [
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA')
-            ] : [],
+            'options' => extension_loaded('pdo_mysql') ? (function () {
+                $sslCa = env('MYSQL_ATTR_SSL_CA');
+
+                if (!$sslCa) {
+                    return [];
+                }
+
+                if (defined('Pdo\Mysql::ATTR_SSL_CA')) {
+                    return [
+                        \Pdo\Mysql::ATTR_SSL_CA => $sslCa,
+                    ];
+                }
+
+                return [
+                    \PDO::MYSQL_ATTR_SSL_CA => $sslCa,
+                ];
+            })() : [],
         ],
 
         'pgsql' => [


### PR DESCRIPTION
This PR updates the MySQLDriver to support PHP 8.5, where MySQL-specific PDO constants have been moved 
from:
```php
PDO::MYSQL_ATTR_*
```
to:
```php
Pdo\Mysql::ATTR_*
```

The legacy `PDO::MYSQL_* `constants are deprecated in PHP 8.5 and trigger fatal errors when deprecations are converted to exceptions.
