### PR TITLE
remove preInstall from composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
             "@php pool config:clear --ansi"
         ],
         "post-create-project-cmd": [
-            "Phaseolies\\Installer::preInstall",
             "Phaseolies\\Installer::postCreateProject",
             "@php pool key:generate --ansi",
             "@php pool package:install --ansi",


### PR DESCRIPTION
Remove preinstall to avoid this warning
```php
Method `Phaseolies\Installer::preInstall` is not callable, can not call post-create-project-cmd script
```
