### PR TITLE
Add explicit request termination lifecycle and terminable dispatch result

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,8 @@
 <?php
 
 use Phaseolies\Application;
+use Phaseolies\Http\Request;
+use Phaseolies\Http\Response;
 
 $basePath = empty(env('APP_BASE_PATH')) ? dirname(__DIR__) : env('APP_BASE_PATH');
 
@@ -25,12 +27,14 @@ $app = new Application();
 | incoming requests and send responses back to the client.
 |
 */
-return $app
-    ->withBasePath(basePath: $basePath)
+return $app->withBasePath(basePath: $basePath)
     ->setRelaxablePaths(relaxablePaths: [
         // The paths listed below will bypass CSRF token verification.
         // '/webhook/payment' – bypasses only the '/webhook/payment' URI.
         // '/webhook/*' – bypasses all URIs that start with '/webhook'.
     ])
+    ->terminating(function (Request $request, ?Response $response, ?\Throwable $exception = null) {
+        // Runs after the response is sent, during application termination.
+    })
     ->configure(app: $app)
     ->build();

--- a/public/index.php
+++ b/public/index.php
@@ -26,7 +26,17 @@ require __DIR__ . '/../bootstrap/app.php';
 
 /*
 |--------------------------------------------------------------------------
-| Dispatch the Request and get the Response
+| Capture the incoming HTTP request, dispatch it through the application,
+| prepare and send the resolved response to the client, and return the
+| dispatch result instance for lifecycle termination handling.
 |--------------------------------------------------------------------------
 */
-$app->dispatch(Request::capture());
+$response = $app->dispatch(Request::capture());
+
+/*
+|--------------------------------------------------------------------------
+| Complete the request lifecycle by running the registered termination
+| callbacks after the response has already been sent.
+|--------------------------------------------------------------------------
+*/
+$response->terminate();


### PR DESCRIPTION
This change introduces a dedicated post-response termination lifecycle for Doppar’s HTTP flow and makes it available through an explicit terminable dispatch result.

Previously, the request lifecycle ended when the response was prepared and sent, but there was no clean framework-level hook for running post-response logic such as logging, cleanup, metrics, audit handling, or deferred request-side work. This update adds that capability in a structured way while keeping the request/response flow backward compatible.

Now, from the skeleton app, `public/index.php` will end like this way.
```php
$response = $app->dispatch(Request::capture());
$response->terminate();
```

And `bootstrap/app.php` get a new method `terminating()`
```php
return $app
    ->withBasePath(basePath: $basePath)
    ->setRelaxablePaths(relaxablePaths: [
        // The paths listed below will bypass CSRF token verification.
        // This is useful for APIs, webhooks, or routes where CSRF protection is not required.
        // '/webhook/payment' – bypasses only the '/webhook/payment' URI.
        // '/webhook/*' – bypasses all URIs that start with '/webhook'.
        // '/tags/*',
    ])
    ->terminating(function (Request $request, ?Response $response, ?\Throwable $exception = null) {
        // Runs after the response is sent, during application termination.
    })
    ->configure(app: $app)
    ->build();
 ```   