### PR TITLE
Rename ServiceProvider to Launcher

### DIFF
--- a/runtime/config/app.php
+++ b/runtime/config/app.php
@@ -111,18 +111,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Application Service Providers
+    | Application Launchers
     |--------------------------------------------------------------------------
     |
-    | Here we register all of the application's service providers. These providers
-    | bootstrap core application services and register important bindings. Providers
+    | Here we register all of the application's launchers. These launchers
+    | bootstrap core application services and register important bindings. Launchers
     | are loaded in the order they are listed below.
     |
-    | Additional providers may be added for specific user implemented features and for packages.
+    | Additional launchers may be added for specific user implemented features and for packages.
     |
     */
-    "providers" => [
-        App\Providers\AppServiceProvider::class,
+    "launchers" => [
+        App\Launchers\AppLauncher::class,
     ],
 
     /*

--- a/src/Launchers/AppLauncher.php
+++ b/src/Launchers/AppLauncher.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Providers;
+namespace App\Launchers;
 
-use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Launchers\ServiceLauncher;
 
-class AppServiceProvider extends ServiceProvider
+class AppLauncher extends ServiceLauncher
 {
     /**
      * Register any application services.
@@ -17,11 +17,11 @@ class AppServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap any application services.
+     * Launch any application services.
      *
      * @return void
      */
-    public function boot(): void
+    public function launch(): void
     {
         //
     }


### PR DESCRIPTION
This PR proposes renaming Doppar's ServiceProvider concept to Launcher.

## Motivation

Doppar currently follows a service-provider-based architecture similar to Laravel. However, ServiceProvider is strongly associated with Laravel's terminology.

Using Launcher gives Doppar its own terminology while keeping the same underlying architecture and lifecycle.

## Benefits

1. Establishes Doppar-specific terminology.
2. Launcher clearly represents the responsibility of initializing and bootstrapping application services.
3. Keeps the existing register() and boot() lifecycle concepts.
4. Makes Doppar's architecture more distinctive without introducing a major architectural change.