### PR TITLE
Route attribute namespace updated in 4.x

### DIFF
--- a/src/Http/Controllers/WelcomeController.php
+++ b/src/Http/Controllers/WelcomeController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use Phaseolies\Utilities\Attributes\Route;
 use Phaseolies\Http\Response;
+use Phaseolies\Support\Router\Attributes\Route;
 use App\Http\Controllers\Controller;
 
 class WelcomeController extends Controller


### PR DESCRIPTION
Previous namespace was:
```
Phaseolies\Utilities\Attributes\Route;
```

for 4.x, it is going to be
```
Phaseolies\Support\Router\Attributes\Route;
```